### PR TITLE
Add environment based deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # Jenkins Hello World
 
 This repository contains a simple `index.html` page and a Jenkins pipeline
-for building and deploying the page to IIS on port `9091`.
+for building and deploying the page to IIS. The deployment port and site
+name are chosen based on the selected environment (`dev`, `qa`, `uat` or
+`prod`).
 
 The pipeline demonstrates:
 
 * Archiving build files.
 * Using environment variables and Jenkins credentials.
-* Deploying to IIS after manual approval.
+* Deploying to IIS after manual approval using the environment-specific port
+  and site name.
 * Publishing a dummy package step to GitHub Packages.
 * Running a sample JUnit test report.
 * Sending an email notification after deployment.


### PR DESCRIPTION
## Summary
- support deployment environments (dev, qa, uat, prod)
- dynamically set port and site name based on environment
- update README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684142c6aa148323964289825d84ef8e